### PR TITLE
Update formula

### DIFF
--- a/git-duet.rb
+++ b/git-duet.rb
@@ -4,10 +4,10 @@ class GitDuet < Formula
   version "0.5.0"
   if OS.mac?
     url "https://github.com/git-duet/git-duet/releases/download/0.5.0/darwin_amd64.tar.gz"
-    sha256 "adc9fe97c99e92fdb160ad29413ec437e125d454590f41be1b91924a4c9efb09"
+    sha256 "88050ceb98480a7917106180c4d81764f94db5719ad3b458b90ac7af6cee9849"
   elsif OS.linux?
     url "https://github.com/git-duet/git-duet/releases/download/0.5.0/linux_amd64.tar.gz"
-    sha256 "e4f767b4c41772641b9178ed3f1d45f6f5f1d3b9b8509fe7016f5376aa181474"
+    sha256 "37ddd1285b5a58c4c3f03cc310a5b0d4af7eaa7a24ce44fd69206fe25aabd949"
   end
 
   depends_on :arch => :x86_64

--- a/git-duet.rb
+++ b/git-duet.rb
@@ -1,6 +1,7 @@
 class GitDuet < Formula
   desc "Pairing tool for Git"
   homepage "https://github.com/git-duet/git-duet"
+  version "0.3.1"
   if OS.mac?
     url "https://github.com/git-duet/git-duet/releases/download/0.3.1/darwin_amd64.tar.gz"
     sha256 "af2e048cda79606d3c90a89ae16a1f0d99866b43daabf01bda340f019a681617"
@@ -8,7 +9,6 @@ class GitDuet < Formula
     url "https://github.com/git-duet/git-duet/releases/download/0.3.1/linux_amd64.tar.gz"
     sha256 "d704f50ad4e4d10b2d99de82998247548a4f72c269f5e41d076baf4454e8c02f"
   end
-  version "0.3.1"
 
   depends_on :arch => :x86_64
 

--- a/git-duet.rb
+++ b/git-duet.rb
@@ -13,7 +13,7 @@ class GitDuet < Formula
   depends_on :arch => :x86_64
 
   def install
-    %w( git-duet git-duet-commit git-duet-revert git-duet-install-hook git-duet-pre-commit git-solo).each do |exe|
+    %w[git-duet git-duet-commit git-duet-revert git-duet-install-hook git-duet-pre-commit git-solo].each do |exe|
       bin.install exe
     end
   end

--- a/git-duet.rb
+++ b/git-duet.rb
@@ -1,4 +1,5 @@
 class GitDuet < Formula
+  desc "Pairing tool for Git"
   homepage 'https://github.com/git-duet/git-duet'
   if OS.mac?
     url 'https://github.com/git-duet/git-duet/releases/download/0.3.1/darwin_amd64.tar.gz'

--- a/git-duet.rb
+++ b/git-duet.rb
@@ -1,13 +1,13 @@
 class GitDuet < Formula
   desc "Pairing tool for Git"
   homepage "https://github.com/git-duet/git-duet"
-  version "0.3.1"
+  version "0.5.0"
   if OS.mac?
-    url "https://github.com/git-duet/git-duet/releases/download/0.3.1/darwin_amd64.tar.gz"
-    sha256 "af2e048cda79606d3c90a89ae16a1f0d99866b43daabf01bda340f019a681617"
+    url "https://github.com/git-duet/git-duet/releases/download/0.5.0/darwin_amd64.tar.gz"
+    sha256 "adc9fe97c99e92fdb160ad29413ec437e125d454590f41be1b91924a4c9efb09"
   elsif OS.linux?
-    url "https://github.com/git-duet/git-duet/releases/download/0.3.1/linux_amd64.tar.gz"
-    sha256 "d704f50ad4e4d10b2d99de82998247548a4f72c269f5e41d076baf4454e8c02f"
+    url "https://github.com/git-duet/git-duet/releases/download/0.5.0/linux_amd64.tar.gz"
+    sha256 "e4f767b4c41772641b9178ed3f1d45f6f5f1d3b9b8509fe7016f5376aa181474"
   end
 
   depends_on :arch => :x86_64

--- a/git-duet.rb
+++ b/git-duet.rb
@@ -1,7 +1,12 @@
 class GitDuet < Formula
   homepage 'https://github.com/git-duet/git-duet'
-  url 'https://github.com/git-duet/git-duet/releases/download/0.3.1/darwin_amd64.tar.gz'
-  sha256 'af2e048cda79606d3c90a89ae16a1f0d99866b43daabf01bda340f019a681617'
+  if OS.mac?
+    url 'https://github.com/git-duet/git-duet/releases/download/0.3.1/darwin_amd64.tar.gz'
+    sha256 'af2e048cda79606d3c90a89ae16a1f0d99866b43daabf01bda340f019a681617'
+  elsif OS.linux?
+    url 'https://github.com/git-duet/git-duet/releases/download/0.3.1/linux_amd64.tar.gz'
+    sha256 'd704f50ad4e4d10b2d99de82998247548a4f72c269f5e41d076baf4454e8c02f'
+  end
   version '0.3.1'
 
   depends_on :arch => :x86_64

--- a/git-duet.rb
+++ b/git-duet.rb
@@ -19,6 +19,6 @@ class GitDuet < Formula
   end
 
   test do
-    system "git duet -h"
+    system "git", "duet", "-h"
   end
 end

--- a/git-duet.rb
+++ b/git-duet.rb
@@ -1,14 +1,14 @@
 class GitDuet < Formula
   desc "Pairing tool for Git"
-  homepage 'https://github.com/git-duet/git-duet'
+  homepage "https://github.com/git-duet/git-duet"
   if OS.mac?
-    url 'https://github.com/git-duet/git-duet/releases/download/0.3.1/darwin_amd64.tar.gz'
-    sha256 'af2e048cda79606d3c90a89ae16a1f0d99866b43daabf01bda340f019a681617'
+    url "https://github.com/git-duet/git-duet/releases/download/0.3.1/darwin_amd64.tar.gz"
+    sha256 "af2e048cda79606d3c90a89ae16a1f0d99866b43daabf01bda340f019a681617"
   elsif OS.linux?
-    url 'https://github.com/git-duet/git-duet/releases/download/0.3.1/linux_amd64.tar.gz'
-    sha256 'd704f50ad4e4d10b2d99de82998247548a4f72c269f5e41d076baf4454e8c02f'
+    url "https://github.com/git-duet/git-duet/releases/download/0.3.1/linux_amd64.tar.gz"
+    sha256 "d704f50ad4e4d10b2d99de82998247548a4f72c269f5e41d076baf4454e8c02f"
   end
-  version '0.3.1'
+  version "0.3.1"
 
   depends_on :arch => :x86_64
 
@@ -19,6 +19,6 @@ class GitDuet < Formula
   end
 
   test do
-    system 'git duet -h'
+    system "git duet -h"
   end
 end

--- a/git-duet.rb
+++ b/git-duet.rb
@@ -19,6 +19,6 @@ class GitDuet < Formula
   end
 
   test do
-    system "git", "duet", "-h"
+    assert_match /#{version.to_s}/, `git duet -v 2>&1`.chomp
   end
 end

--- a/git-duet.rb
+++ b/git-duet.rb
@@ -13,7 +13,7 @@ class GitDuet < Formula
   depends_on :arch => :x86_64
 
   def install
-    %w[git-duet git-duet-commit git-duet-revert git-duet-install-hook git-duet-pre-commit git-solo].each do |exe|
+    %w[git-duet git-duet-commit git-duet-revert git-duet-install-hook git-duet-merge git-duet-pre-commit git-solo].each do |exe|
       bin.install exe
     end
   end


### PR DESCRIPTION
- Add Linux support (so git-duet can be installed with [linuxbrew](http://linuxbrew.sh/))
- Bump version to 0.5.0
- Fix minor faults found by homebrew audit tests
  - `brew audit --new-formula git-duet`

~~Note that when I installed git-duet with this new formula, it didn't support the new `--version` option.~~ **Update:** Wrong version was released, see https://github.com/git-duet/git-duet/issues/40