### PR TITLE
Get git-duet version for brew test from STDOUT

### DIFF
--- a/git-duet.rb
+++ b/git-duet.rb
@@ -19,6 +19,6 @@ class GitDuet < Formula
   end
 
   test do
-    assert_match /#{version.to_s}/, `git duet -v 2>&1`.chomp
+    assert_match /#{version.to_s}/, `git duet -v`.chomp
   end
 end

--- a/git-duet.rb
+++ b/git-duet.rb
@@ -1,13 +1,13 @@
 class GitDuet < Formula
   desc "Pairing tool for Git"
   homepage "https://github.com/git-duet/git-duet"
-  version "0.5.0"
+  version "0.5.1"
   if OS.mac?
-    url "https://github.com/git-duet/git-duet/releases/download/0.5.0/darwin_amd64.tar.gz"
-    sha256 "88050ceb98480a7917106180c4d81764f94db5719ad3b458b90ac7af6cee9849"
+    url "https://github.com/git-duet/git-duet/releases/download/0.5.1/darwin_amd64.tar.gz"
+    sha256 "28d90acd34291fe98505f9f808cbd36d2c8cc2828a1ec6da7c699058468d2e86"
   elsif OS.linux?
-    url "https://github.com/git-duet/git-duet/releases/download/0.5.0/linux_amd64.tar.gz"
-    sha256 "37ddd1285b5a58c4c3f03cc310a5b0d4af7eaa7a24ce44fd69206fe25aabd949"
+    url "https://github.com/git-duet/git-duet/releases/download/0.5.1/linux_amd64.tar.gz"
+    sha256 "0762f5845928feb04a7e43de55330feae2fd4a2f280a964e818aa336706d924d"
   end
 
   depends_on :arch => :x86_64


### PR DESCRIPTION
Bump version to 0.5.1 and update brew test to use STDOUT.

Depends on https://github.com/git-duet/git-duet/pull/42