### PR TITLE
use brew install instead of brew tap + brew install

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,5 @@
 To install `git-duet` with Homebrew:
 
 ```bash
-$ brew tap git-duet/tap
-$ brew install git-duet
+brew install git-duet/tap/git-duet
 ```


### PR DESCRIPTION
This is a follow up commit to https://github.com/git-duet/git-duet/pull/85.