### PR TITLE
Fix links for Darwin

### DIFF
--- a/git-duet.rb
+++ b/git-duet.rb
@@ -5,11 +5,11 @@ class GitDuet < Formula
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/git-duet/git-duet/releases/download/0.9.0/darwin_arm64.tar.gz"
-      sha256 "3e6b20dd909a0b47763f6659828ad5b3860dcf8995ff12d221d911b8ecdd51c3"
-    elsif Hardware::CPU.arm?
       url "https://github.com/git-duet/git-duet/releases/download/0.9.0/darwin_amd64.tar.gz"
       sha256 "7e72fb8425f49cf436ab3808273cb1013719ae39a66169adf0a1c2c8aa4a72fc"
+    elsif Hardware::CPU.arm?
+      url "https://github.com/git-duet/git-duet/releases/download/0.9.0/darwin_arm64.tar.gz"
+      sha256 "3e6b20dd909a0b47763f6659828ad5b3860dcf8995ff12d221d911b8ecdd51c3"
     end
   end
 


### PR DESCRIPTION
I accidentally reversed the ARM64 and AMD64 links and checksums

Fixes: https://github.com/git-duet/git-duet/issues/111

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>
