### PR TITLE
Fix checksums for 0.10.0

### DIFF
--- a/git-duet.rb
+++ b/git-duet.rb
@@ -6,17 +6,17 @@ class GitDuet < Formula
   on_macos do
     if Hardware::CPU.intel?
       url "https://github.com/git-duet/git-duet/releases/download/0.10.0/darwin_amd64.tar.gz"
-      sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      sha256 "fbc42f6388dbccb7f080992241e03de4c61bf4e2fec0fa875f5e8b4f403788dd"
     elsif Hardware::CPU.arm?
       url "https://github.com/git-duet/git-duet/releases/download/0.10.0/darwin_arm64.tar.gz"
-      sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      sha256 "edf84e298029571b5f377993abb50d3c553cdb953cc3ff1acf136802d5e40165"
     end
   end
 
   on_linux do
     if Hardware::CPU.intel?
       url "https://github.com/git-duet/git-duet/releases/download/0.10.0/linux_amd64.tar.gz"
-      sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      sha256 "c6db0838dddbb76604bdf02dc086dd0fb105096b4b468438a16cf4bcb40ad6f0"
     end
   end
 


### PR DESCRIPTION
## Problem

I support developer environments at Gusto, and we started seeing this error when running updates:
```
==> Fetching git-duet/tap/git-duet
==> Downloading https://github.com/git-duet/git-duet/releases/download/0.10.0/darwin_arm64.tar.gz
Already downloaded: /Users/andrew.herr/Library/Caches/Homebrew/downloads/344e74d514a80174e411a3761672def8ca7701c8e06a614ea16d70fa836e37fd--darwin_arm64.tar.gz
Error: SHA256 mismatch
Expected: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
  Actual: edf84e298029571b5f377993abb50d3c553cdb953cc3ff1acf136802d5e40165
```

Fixes https://github.com/git-duet/homebrew-tap/issues/14


## Solution

Update SHA values from fresh GitHub downloads:
```
❯ sha256sum ~/Downloads/darwin_arm64.tar.gz
edf84e298029571b5f377993abb50d3c553cdb953cc3ff1acf136802d5e40165  /Users/adam.neumann/Downloads/darwin_arm64.tar.gz

❯ sha256sum ~/Downloads/darwin_amd64.tar.gz
fbc42f6388dbccb7f080992241e03de4c61bf4e2fec0fa875f5e8b4f403788dd  /Users/adam.neumann/Downloads/darwin_amd64.tar.gz

❯ sha256sum ~/Downloads/linux_amd64.tar.gz
c6db0838dddbb76604bdf02dc086dd0fb105096b4b468438a16cf4bcb40ad6f0  /Users/adam.neumann/Downloads/linux_amd64.tar.gz

```
